### PR TITLE
fix: use https for _config.yml url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Moving # The title of the blog
 author: Your Name # Your name 
 email: your-email@domain.com # your email shown in the footer
-url: http://huangyz.name/moving/ # this is your site's root address.
+url: https://huangyz.name/moving/ # this is your site's root address.
 description: > # this means to ignore newlines until "show_excerpts:"
   A clean and minimalist theme for Jekyll.
 favicon: "./favicon.ico" # set the favicon of the site 


### PR DESCRIPTION
Use https for the url value in _config.yml. This url is used to request a couple style sheets. On certain browsers (chrome) mixed content is blocked by default so the request fails.

Found this by `enforcing https` on my github pages.

![image](https://user-images.githubusercontent.com/7028984/72326762-c7da3600-367d-11ea-8cb9-2eefe83662c4.png)
